### PR TITLE
Require OpenShift host env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ code/compile:
 
 .PHONY: code/run
 code/run: code/gen
+ifndef OPENSHIFT_HOST
+	$(error OPENSHIFT_HOST is undefined)
+endif
 	operator-sdk up local
 
 .PHONY: code/gen

--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
 
 ```
 
+# make sure you enabled CORS addon on Minishift
+# https://github.com/aerogear/mobile-developer-console#enable-cors-in-the-openshift-cluster
+
+if minishift addons list | grep cors ; then
+    minishift addons apply cors
+else
+    MINISHIFT_ADDONS_PATH=/tmp/minishift-addons
+    rm -rf $MINISHIFT_ADDONS_PATH && git clone https://github.com/minishift/minishift-addons.git $MINISHIFT_ADDONS_PATH
+    # Not needed after https://github.com/minishift/minishift-addons/pull/187 is merged
+    cd $MINISHIFT_ADDONS_PATH
+    git fetch origin pull/187/head:cors-fix && git checkout cors-fix
+    minishift addons install /tmp/minishift-addons/add-ons/cors
+    minishift addons apply cors
+fi
+minishift addon apply cors
+
 oc login -u system:admin
 make cluster/clean
 make cluster/prepare
 
-make code/run
+OPENSHIFT_HOST=$(minishift ip):8443 make code/run
 
-
-TODO:
-oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,update,watch --resource=mobileclients
-oc adm policy add-cluster-role-to-user mobileclient-admin system:serviceaccount:mdc:example-mobiledeveloperconsole 
 
 kubectl apply  -n mdc -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
 ```

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -76,6 +77,13 @@ func main() {
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)
+	}
+
+	if openShiftHost, exists := os.LookupEnv("OPENSHIFT_HOST"); exists == false {
+		log.Error(errors.New("no OPENSHIFT_HOST is set"), "no OPENSHIFT_HOST is set")
+		os.Exit(1)
+	} else {
+		log.Info("MDC instances managed are going to target", "OpenShiftHost", openShiftHost)
 	}
 
 	ctx := context.TODO()

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -30,3 +30,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "mobile-developer-console-operator"
+            - name: OPENSHIFT_HOST
+              value: "${OPENSHIFT_HOST}"  # to be filled by whoever is deploying this file

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,8 @@ package config
 import "os"
 
 type Config struct {
+	OpenShiftHost string
+
 	MDCContainerName        string
 	OauthProxyContainerName string
 
@@ -17,6 +19,8 @@ type Config struct {
 
 func New() Config {
 	return Config{
+		OpenShiftHost: getReqEnv("OPENSHIFT_HOST"),
+
 		MDCContainerName:        getEnv("MDC_CONTAINER_NAME", "mdc"),
 		OauthProxyContainerName: getEnv("OAUTH_PROXY_CONTAINER_NAME", "mdc-oauth-proxy"),
 
@@ -37,4 +41,12 @@ func getEnv(key string, defaultVal string) string {
 	}
 
 	return defaultVal
+}
+
+func getReqEnv(key string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+
+	panic("Required env var is missing: " + key)
 }

--- a/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
+++ b/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
@@ -209,7 +209,7 @@ func newMDCDeploymentConfig(cr *mdcv1alpha1.MobileDeveloperConsole) (*openshifta
 								},
 								{
 									Name:  "OPENSHIFT_HOST",
-									Value: "WHAT!", // TODO TODO TODO
+									Value: cfg.OpenShiftHost,
 								},
 							},
 							Ports: []corev1.ContainerPort{


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9107

As we discussed, the operator will accept a OPENSHIFT_HOST param and will pass it to MDC instances it creates.

Happy case (running outside of the cluster):
```
oc login -u system:admin
make cluster/clean
make cluster/prepare

OPENSHIFT_HOST=$(minishift ip):8443 make code/run

# TO BE ADDRESSED LATER
oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,update,watch --resource=mobileclients
oc adm policy add-cluster-role-to-user mobileclient-admin system:serviceaccount:mdc:example-mobiledeveloperconsole 

# create CR
kubectl apply  -n mdc -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
```

Happy case (running inside the cluster):
* Build locally: `operator-sdk build aliok/foo-bar`
* Push `docker push aliok/foo-bar`
* Change the image name and the `OPENSHIFT_HOST` param in `deploy/operator.yaml`
* `oc create -f deploy/operator.yaml`

 Bad cases:
1. Try to execute `code/run` without the env var `OPENSHIFT_HOST`. This only is about running the operator locally outside the cluster.
2. Try to deploy the operator without the env var `OPENSHIFT_HOST` inside the cluster. Leave the param in `deploy/operator.yaml`.


Problems:
* There is still some RBAC and Oauth config issues in the MDC instances created. Please ignore them for now and check the deployment, service etc. being created. PR is blocked for too long if I also try to fix those now.