### PR TITLE
Oauth proxy proper config, Oauth client manual config, RBAC manual config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,30 @@ make cluster/prepare
 OPENSHIFT_HOST=$(minishift ip):8443 make code/run
 
 
-kubectl apply  -n mdc -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
+kubectl apply  -n mobile-developer-console -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
+
+AFTER WORK - things that aren't done by the operator yet.
+
+MDC_ROUTE=$(oc -n mobile-developer-console get route example-mdc-mdc-proxy --template "{{.spec.host}}")
+
+cat <<EOF | oc apply -f -
+apiVersion: v1
+grantMethod: auto
+kind: OAuthClient
+metadata:
+  name: mobile-developer-console
+secret: SECRETPLACEHOLDER
+redirectURIs: ["https://${MDC_ROUTE}"]
+EOF
+
+
+# needed to make the MDC server side SA to list/watch/etc some resources in all namespaces
+oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,update,watch --resource=mobileclients,secrets,configmaps
+oc adm policy add-cluster-role-to-user mobileclient-admin system:serviceaccount:mobile-developer-console:example-mdc
+
+# not sure if we need the same things for keycloakrealms, mobilesecurityserviceapps
+
+
+oc rollout latest example-mdc
+
 ```

--- a/deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
+++ b/deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
@@ -1,4 +1,4 @@
 apiVersion: mdc.aerogear.org/v1alpha1
 kind: MobileDeveloperConsole
 metadata:
-  name: example-mobiledeveloperconsole
+  name: example-mdc

--- a/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
+++ b/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
@@ -233,12 +233,16 @@ func newMDCDeploymentConfig(cr *mdcv1alpha1.MobileDeveloperConsole) (*openshifta
 							},
 							Args: []string{
 								"--provider=openshift",
-								fmt.Sprintf("--openshift-service-account=%s", cr.Name),
+								"--client-id=mobile-developer-console",
+								"--client-secret=SECRETPLACEHOLDER",
 								"--upstream=http://localhost:4000",
 								"--http-address=0.0.0.0:4180",
 								"--skip-auth-regex=/rest/sender,/rest/registry/device,/rest/prometheus/metrics,/rest/auth/config",
 								"--https-address=",
 								fmt.Sprintf("--cookie-secret=%s", cookieSecret),
+								"--cookie-httponly=false", // we kill the possibility to run MDC on a http route
+								"--pass-access-token=true",
+								"--scope=user:full",
 							},
 						},
 					},


### PR DESCRIPTION
Builds on top of https://github.com/aerogear/mobile-developer-console-operator/pull/3

I did some work to set up the Oauth proxy correctly.
That requires registering a Oauth client, which we don't do with the operator yet.

However I provided some instructions for the Oauth client creation to test the Oauth proxy config in the deployment config. Let's review and merge that change and then we can make the client registered by the operator.

Similarly, the RBAC issues are solved, but I only created manual instructions so far.

Appreciate your feedback on the commands before converting them to Golang code.

```bash
# START STUFF
oc login -u system:admin
make cluster/clean
make cluster/prepare

OPENSHIFT_HOST=$(minishift ip):8443 make code/run

# DEPLOY A MDC INSTANCE

kubectl apply  -n mobile-developer-console -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
```

AFTER WORK - things that aren't done by the operator yet.
```bash
# need to MDC url for Oauth redirection
MDC_ROUTE=$(oc -n mobile-developer-console get route example-mdc-mdc-proxy --template "{{.spec.host}}")

cat <<EOF | oc apply -f -
apiVersion: v1
grantMethod: auto
kind: OAuthClient
metadata:
  name: mobile-developer-console
secret: SECRETPLACEHOLDER
redirectURIs: ["https://${MDC_ROUTE}"]
EOF

# needed to make the MDC server side SA to list/watch/etc some resources in all namespaces
oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,update,watch --resource=mobileclients,secrets,configmaps
oc adm policy add-cluster-role-to-user mobileclient-admin system:serviceaccount:mobile-developer-console:example-mdc

# not sure if we need the same things for keycloakrealms, mobilesecurityserviceapps

# redeploy to make the changes effective in the MDC pods
oc rollout latest example-mdc
```