### PR TITLE
Create OAuthClient within the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ setup/travis:
 	@echo setup complete
 
 .PHONY: code/compile
-code/compile:
+code/compile: code/gen
 	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o=$(CODE_COMPILE_OUTPUT) ./cmd/manager/main.go
 
 .PHONY: code/run
@@ -30,6 +30,7 @@ endif
 .PHONY: code/gen
 code/gen: code/fix
 	operator-sdk generate k8s
+	operator-sdk generate openapi
 	go generate ./...
 
 .PHONY: code/fix
@@ -53,7 +54,7 @@ cluster/prepare:
 	-kubectl create -n $(NAMESPACE) -f deploy/role.yaml
 	-kubectl create -n $(NAMESPACE) -f deploy/role_binding.yaml
 	-kubectl apply  -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
-	-kubectl apply  -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobileclient_crd.yaml
+	-kubectl apply  -n $(NAMESPACE) -f deploy/mdc_v1alpha1_mobileclient_crd.yaml
 
 .PHONY: cluster/clean
 cluster/clean:
@@ -62,7 +63,7 @@ cluster/clean:
 	-kubectl delete -n $(NAMESPACE) -f deploy/role_binding.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/service_account.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
-	-kubectl delete -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobileclient_crd.yaml
+	-kubectl delete -n $(NAMESPACE) -f deploy/mdc_v1alpha1_mobileclient_crd.yaml
 	-kubectl delete namespace $(NAMESPACE)
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -93,21 +93,11 @@ Please take the following steps manually for now after the above install steps
 
 ```
 AFTER WORK - things that aren't done by the operator yet.
- MDC_ROUTE=$(oc -n mobile-developer-console get route example-mdc-mdc-proxy --template "{{.spec.host}}")
- cat <<EOF | oc apply -f -
-apiVersion: v1
-grantMethod: auto
-kind: OAuthClient
-metadata:
-  name: mobile-developer-console
-secret: SECRETPLACEHOLDER
-redirectURIs: ["https://${MDC_ROUTE}"]
-EOF
- # needed to make the MDC server side SA to list/watch/etc some resources in all namespaces
+# needed to make the MDC server side SA to list/watch/etc some resources in all namespaces
 oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,update,watch --resource=mobileclients,secrets,configmaps
 oc adm policy add-cluster-role-to-user mobileclient-admin system:serviceaccount:mobile-developer-console:example-mdc
- # not sure if we need the same things for keycloakrealms, mobilesecurityserviceapps
- oc rollout latest example-mdc
+# not sure if we need the same things for keycloakrealms, mobilesecurityserviceapps
+oc rollout latest example-mdc
 ```
 
 == Getting help

--- a/README.md
+++ b/README.md
@@ -28,19 +28,6 @@ kubectl apply  -n mobile-developer-console -f deploy/crds/mdc_v1alpha1_mobiledev
 
 AFTER WORK - things that aren't done by the operator yet.
 
-MDC_ROUTE=$(oc -n mobile-developer-console get route example-mdc-mdc-proxy --template "{{.spec.host}}")
-
-cat <<EOF | oc apply -f -
-apiVersion: v1
-grantMethod: auto
-kind: OAuthClient
-metadata:
-  name: mobile-developer-console
-secret: SECRETPLACEHOLDER
-redirectURIs: ["https://${MDC_ROUTE}"]
-EOF
-
-
 # needed to make the MDC server side SA to list/watch/etc some resources in all namespaces
 oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,update,watch --resource=mobileclients,secrets,configmaps
 oc adm policy add-cluster-role-to-user mobileclient-admin system:serviceaccount:mobile-developer-console:example-mdc

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -16,6 +16,7 @@ import (
 
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -127,6 +128,12 @@ func main() {
 
 	// Setup Scheme for OpenShift Image apis
 	if err := imagev1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup Scheme for OpenShift OAuth apis
+	if err := oauthv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,3 +32,7 @@ func GeneratePassword() (string, error) {
 	}
 	return strings.Replace(generatedPassword.String(), "-", "", -1), nil
 }
+
+func NameWithNamespace(namespace, name, suffix string) string {
+	return fmt.Sprintf("%s-%s-%s", namespace, name, suffix)
+}


### PR DESCRIPTION
## Verification:

Setup:
```
# make sure you enabled CORS addon on Minishift
# https://github.com/aerogear/mobile-developer-console#enable-cors-in-the-openshift-cluster

if minishift addons list | grep cors ; then
    minishift addons apply cors
else
    MINISHIFT_ADDONS_PATH=/tmp/minishift-addons
    rm -rf $MINISHIFT_ADDONS_PATH && git clone https://github.com/minishift/minishift-addons.git $MINISHIFT_ADDONS_PATH
    # Not needed after https://github.com/minishift/minishift-addons/pull/187 is merged
    cd $MINISHIFT_ADDONS_PATH
    git fetch origin pull/187/head:cors-fix && git checkout cors-fix
    minishift addons install /tmp/minishift-addons/add-ons/cors
    minishift addons apply cors
fi
minishift addon apply cors

oc login -u system:admin
make cluster/clean
make cluster/prepare

OPENSHIFT_HOST=$(minishift ip):8443 make code/run

```

Create CR:
```
kubectl apply  -n mobile-developer-console -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
```

Need to do this as well:
```
oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,update,watch --resource=mobileclients,secrets,configmaps
oc adm policy add-cluster-role-to-user mobileclient-admin system:serviceaccount:mobile-developer-console:example-mdc
oc rollout latest example-mdc
```

* Open the MDC console in your browser.
* You should be redirected to Oauth login screen.
* After login you should see the MDC console.

Problems:
* The oauthClient is not deleted when the CR is deleted