### PR TITLE
Create ClusterRoleBinding for MDC SA in operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,12 @@ cluster/clean:
 	-kubectl delete namespace $(NAMESPACE)
 
 
-.PHONY: install
+.PHONY: install-operator
 install:
 	-kubectl apply -n $(NAMESPACE) -f deploy/operator.yaml
+
+.PHONY: install-mdc
+install:
 	-kubectl apply -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml
 
 .PHONY: uninstall

--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,13 @@ test/compile:
 
 .PHONY: cluster/prepare
 cluster/prepare:
-	-kubectl create -f deploy/clusterrole.yaml
-	-kubectl create -f deploy/role.yaml
-	-kubectl apply  -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
 	-kubectl create namespace $(NAMESPACE)
 	-kubectl label namespace $(NAMESPACE) monitoring-key=middleware
 	-kubectl create -n $(NAMESPACE) -f deploy/service_account.yaml
+	-kubectl create -n $(NAMESPACE) -f deploy/role.yaml
+	-kubectl create -n $(NAMESPACE) -f deploy/clusterrole.yaml
 	-kubectl create -n $(NAMESPACE) -f deploy/role_binding.yaml
+	-kubectl apply  -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
 	-kubectl apply  -n $(NAMESPACE) -f deploy/mdc_v1alpha1_mobileclient_crd.yaml
 
 .PHONY: cluster/clean
@@ -62,10 +62,10 @@ cluster/clean:
 	make uninstall
 	-kubectl delete -f deploy/role.yaml
 	-kubectl delete -f deploy/clusterrole.yaml
-	-kubectl delete -f deploy/mdc_v1alpha1_mobileclient_crd.yaml
-	-kubectl delete -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/role_binding.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/service_account.yaml
+	-kubectl delete -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
+	-kubectl delete -n $(NAMESPACE) -f deploy/mdc_v1alpha1_mobileclient_crd.yaml
 	-kubectl delete namespace $(NAMESPACE)
 
 

--- a/Makefile
+++ b/Makefile
@@ -48,22 +48,24 @@ test/compile:
 
 .PHONY: cluster/prepare
 cluster/prepare:
+	-kubectl create -f deploy/clusterrole.yaml
+	-kubectl create -f deploy/role.yaml
+	-kubectl apply  -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
 	-kubectl create namespace $(NAMESPACE)
 	-kubectl label namespace $(NAMESPACE) monitoring-key=middleware
 	-kubectl create -n $(NAMESPACE) -f deploy/service_account.yaml
-	-kubectl create -n $(NAMESPACE) -f deploy/role.yaml
 	-kubectl create -n $(NAMESPACE) -f deploy/role_binding.yaml
-	-kubectl apply  -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
 	-kubectl apply  -n $(NAMESPACE) -f deploy/mdc_v1alpha1_mobileclient_crd.yaml
 
 .PHONY: cluster/clean
 cluster/clean:
 	make uninstall
 	-kubectl delete -f deploy/role.yaml
+	-kubectl delete -f deploy/clusterrole.yaml
+	-kubectl delete -f deploy/mdc_v1alpha1_mobileclient_crd.yaml
+	-kubectl delete -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/role_binding.yaml
 	-kubectl delete -n $(NAMESPACE) -f deploy/service_account.yaml
-	-kubectl delete -n $(NAMESPACE) -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_crd.yaml
-	-kubectl delete -n $(NAMESPACE) -f deploy/mdc_v1alpha1_mobileclient_crd.yaml
 	-kubectl delete namespace $(NAMESPACE)
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -84,15 +84,21 @@ mobile-security-service-operator in your OpenShift cluster as follows:
 ....
 make cluster/prepare
 make install
-oc set env deployment/$(oc get -n mobile-developer-console -f deploy/operator.yaml --template "{{.metadata.name}}") OPENSHIFT_HOST="${OPENSHIFT_HOST}"
+OPENSHIFT_HOST=https://your-openshift-host
+# or OPENSHIFT_HOST=$(minishift ip), as described in previous section
+oc set env deployment/$(oc get -f deploy/operator.yaml --template "{{.metadata.name}}") OPENSHIFT_HOST="${OPENSHIFT_HOST}"
 ....
 
 
-== Post installation work
+== Post installation
 
-TODO
+Once the `mobiledeveloperconsole` CR is created in `make install` above, the operator will provision a Mobile Developer Console instance.
+`make install` command above will not create the required OAuthClient on purpose as we need the Mobile Developer Console URL, which is not available
+at that time.
 
-```
+Create the necessary OAuthClient with the following commands.
+
+....
 
 OAUTH_CLIENT_ID=$(oc get -n mobile-developer-console -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml --template "{{.spec.oAuthClientId}}")
 OAUTH_CLIENT_SECRET=$(oc get -n mobile-developer-console -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml --template "{{.spec.oAuthClientSecret}}")
@@ -108,14 +114,8 @@ secret: ${OAUTH_CLIENT_SECRET}
 redirectURIs: ["https://${MDC_ROUTE}"]
 EOF
 
-
-# needed to make the MDC server side SA to list/watch/etc some resources in all namespaces
-# not sure if we need the same things for keycloakrealms, mobilesecurityserviceapps
-oc create clusterrole mobileclient-admin --verb=create,delete,get,list,patch,update,watch --resource=mobileclients,secrets,configmaps
-oc adm policy add-cluster-role-to-user mobileclient-admin system:serviceaccount:mobile-developer-console:example-mdc
-
 oc rollout latest example-mdc
-```
+....
 
 == Getting help
 

--- a/README.adoc
+++ b/README.adoc
@@ -73,33 +73,34 @@ minishift addon apply cors
 
 . Export required OPENSHIFT_HOST variable
 ....
-export OPENSHIFT_HOST=$(minishift ip)
+export OPENSHIFT_HOST=https://$(minishift ip)
 ....
 
-== Installation
+== Installing Operator
 
-As a user with admin permissions, you can easily install the
+As a user with admin permissions, you can install the
 mobile-security-service-operator in your OpenShift cluster as follows:
 
 ....
 make cluster/prepare
-make install
+
+make install-operator
 OPENSHIFT_HOST=https://your-openshift-host
-# or OPENSHIFT_HOST=$(minishift ip), as described in previous section
+# or OPENSHIFT_HOST=https://$(minishift ip), as described in previous section
 oc set env deployment/$(oc get -f deploy/operator.yaml --template "{{.metadata.name}}") OPENSHIFT_HOST="${OPENSHIFT_HOST}"
 ....
 
-
-== Post installation
-
-Once the `mobiledeveloperconsole` CR is created in `make install` above, the operator will provision a Mobile Developer Console instance.
-`make install` command above will not create the required OAuthClient on purpose as we need the Mobile Developer Console URL, which is not available
-at that time.
-
-Create the necessary OAuthClient with the following commands.
+== Provisioning MDC
 
 ....
+make install-mdc
+....
 
+Once the `mobiledeveloperconsole` CR is created with the `make install-mdc` above, the operator will provision a Mobile Developer Console instance.
+
+However, an OAuthClient needs to be created with the Mobile Developer Console URL.
+
+....
 OAUTH_CLIENT_ID=$(oc get -n mobile-developer-console -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml --template "{{.spec.oAuthClientId}}")
 OAUTH_CLIENT_SECRET=$(oc get -n mobile-developer-console -f deploy/crds/mdc_v1alpha1_mobiledeveloperconsole_cr.yaml --template "{{.spec.oAuthClientSecret}}")
 MDC_ROUTE=$(oc -n mobile-developer-console get route example-mdc-mdc-proxy --template "{{.spec.host}}")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,6 +17,7 @@ import (
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -127,6 +128,12 @@ func main() {
 
 	// Setup Scheme for OpenShift Image apis
 	if err := imagev1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup Scheme for RBAC apis
+	if err := rbacv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mobileclient-admin
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - mobile.k8s.io
+    resources:
+      - mobileclients
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
+++ b/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
@@ -11,6 +11,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -246,6 +247,27 @@ func newMDCDeploymentConfig(cr *mdcv1alpha1.MobileDeveloperConsole) (*openshifta
 						},
 					},
 				},
+			},
+		},
+	}, nil
+}
+
+func newMobileClientAdminClusterRoleBinding(cr *mdcv1alpha1.MobileDeveloperConsole) (*rbacv1.ClusterRoleBinding, error) {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cr.Namespace,
+			Name:      cr.Namespace + "-" + cr.Name + "-mobileclient-admin",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "mobileclient-admin",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      cr.Name,
+				Namespace: cr.Namespace,
 			},
 		},
 	}, nil


### PR DESCRIPTION
ClusterRoleBinding for MDC SA is now created and reconciled by the MDC operator.
There was a manual step in the README for that, which we don't need anymore.

Verification:
* Follow the steps in README
* Open MDC route on your browser. 
* You should be redirected to Oauth login screen.
* After login you should see the MDC console.