### PR TITLE
feat(docs-link): add env vars to link to downstream docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -147,6 +147,22 @@ browsers. Instructions at the top of the document for enabling CORS in OpenShift
 | None - it is required
 | Public hostname of the OpenShift cluster
 
+|`UPS_DOCUMENTATION_URL`
+| https://docs.aerogear.org/limited-availability/upstream/ups.html
+| Link to documentation for Unified Push service.
+
+|`IDM_DOCUMENTATION_URL`
+| https://docs.aerogear.org/limited-availability/upstream/idm.html
+| Link to documentation for Identity Management service.
+
+|`SYNC_DOCUMENTATION_URL`
+| https://docs.aerogear.org/limited-availability/upstream/sync.html
+| Link to documentation for Data Sync service.
+
+|`MSS_DOCUMENTATION_URL`
+| https://docs.aerogear.org/limited-availability/upstream/mss.html
+| Link to documentation for Mobile Security Service.
+
 |===
 
 === Image Streams

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,3 +32,11 @@ spec:
               value: "mobile-developer-console-operator"
             - name: OPENSHIFT_HOST
               value: "${OPENSHIFT_HOST}"  # to be filled by whoever is deploying this file
+            - name: UPS_DOCUMENTATION_URL
+              value: ""
+            - name: IDM_DOCUMENTATION_URL
+              value: ""
+            - name: SYNC_DOCUMENTATION_URL
+              value: ""
+            - name: MSS_DOCUMENTATION_URL
+              value: ""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,11 @@ type Config struct {
 
 	MDCImageStreamInitialImage        string
 	OauthProxyImageStreamInitialImage string
+
+	UnifiedPushDocumentationURL        string
+	IdentityManagementDocumentationURL string
+	DataSyncDocumentationURL           string
+	MobileSecurityDocumentationURL     string
 }
 
 func New() Config {
@@ -32,6 +37,12 @@ func New() Config {
 		// these are used when the image stream does not exist and created for the first time by the operator
 		MDCImageStreamInitialImage:        getEnv("MDC_IMAGE_STREAM_INITIAL_IMAGE", "quay.io/aerogear/mobile-developer-console:latest"),
 		OauthProxyImageStreamInitialImage: getEnv("OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/openshift/oauth-proxy:v1.1.0"),
+
+		// override the default links displayed in MDC for each of the mobile services
+		UnifiedPushDocumentationURL:        getEnv("UPS_DOCUMENTATION_URL", "https://docs.aerogear.org/limited-availability/upstream/ups.html"),
+		IdentityManagementDocumentationURL: getEnv("IDM_DOCUMENTATION_URL", "https://docs.aerogear.org/limited-availability/upstream/idm.html"),
+		DataSyncDocumentationURL:           getEnv("SYNC_DOCUMENTATION_URL", "https://docs.aerogear.org/limited-availability/upstream/sync.html"),
+		MobileSecurityDocumentationURL:     getEnv("MSS_DOCUMENTATION_URL", "https://docs.aerogear.org/limited-availability/upstream/mss.html"),
 	}
 }
 

--- a/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
+++ b/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
@@ -2,6 +2,7 @@ package mobiledeveloperconsole
 
 import (
 	"fmt"
+
 	"github.com/aerogear/mobile-developer-console-operator/pkg/util"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -211,6 +212,22 @@ func newMDCDeploymentConfig(cr *mdcv1alpha1.MobileDeveloperConsole) (*openshifta
 								{
 									Name:  "OPENSHIFT_HOST",
 									Value: cfg.OpenShiftHost,
+								},
+								{
+									Name:  "IDM_DOCUMENTATION_URL",
+									Value: cfg.IdentityManagementDocumentationURL,
+								},
+								{
+									Name:  "UPS_DOCUMENTATION_URL",
+									Value: cfg.UnifiedPushDocumentationURL,
+								},
+								{
+									Name:  "SYNC_DOCUMENTATION_URL",
+									Value: cfg.DataSyncDocumentationURL,
+								},
+								{
+									Name:  "MSS_DOCUMENTATION_URL",
+									Value: cfg.MobileSecurityDocumentationURL,
 								},
 							},
 							Ports: []corev1.ContainerPort{


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-9630

To verify:

1. `make cluster/prepare` to prepare the cluster.
2. In [operator.yaml](https://github.com/aerogear/mobile-developer-console-operator/blob/842a58a09d8d0cc950ab2dc4c02c11dcc39709d0/deploy/operator.yaml) modify the following values, setting them to some arbitrary URLs.

- UPS_DOCUMENTATION_URL
- IDM_DOCUMENTATION_URL
- SYNC_DOCUMENTATION_URL
- MSS_DOCUMENTATION_URL

3. `make install-operator` to install the operator.
4. `make install-mdc` to install the MDC application.
5. In OpenShift, look at the environment variables in the MDC application. They should refect those that were set in the operator.

![Screenshot from 2019-07-23 12-59-50](https://user-images.githubusercontent.com/11743717/61710555-cae90f00-ad49-11e9-883e-a23069285677.png)

There is no visual verification until https://github.com/aerogear/mobile-developer-console/pull/339 is merged.
