### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -85,7 +85,7 @@ fi
 export OPENSHIFT_HOST=$(minishift ip):8443
 ....
 
-== Remove cluster Prerequisities
+== Remote cluster Prerequisities
 
 If you are using a remote cluster, you should check {openshift_cors} 
 on how to update the CORS configurations.

--- a/README.adoc
+++ b/README.adoc
@@ -23,6 +23,7 @@ endif::[]
 :minishift: https://github.com/minishift/minishift[Minishift]
 :rh_product_security: https://access.redhat.com/security/team/contact[Red Hat Product Security team]
 :minishift_cors: https://github.com/aerogear/mobile-developer-console#enable-cors-in-the-openshift-cluster[steps]
+:openshift_cors: https://docs.openshift.com/container-platform/3.11/install_config/master_node_configuration.html#master-config-asset-config[OpenShift configuration guide]
 
 = Mobile Developer Console Operator
 
@@ -83,6 +84,11 @@ fi
 ....
 export OPENSHIFT_HOST=$(minishift ip):8443
 ....
+
+== Remove cluster Prerequisities
+
+If you are using a remote cluster, you should check {openshift_cors} 
+on how to update the CORS configurations.
 
 == Installing the Operator
 


### PR DESCRIPTION
In the readme, it was only mentioned that CORS should be enabled for Minishift. But it should also be enabled for any remote clusters.

Added a short doc update for that.

Thanks @STEPHINRACHEL for the suggestion.