### PR TITLE
fix(Prometheus Alerts): Remove MDCPodCount since it was considered redundant

### DIFF
--- a/deploy/monitor/prometheus_rule.yaml
+++ b/deploy/monitor/prometheus_rule.yaml
@@ -18,12 +18,3 @@ spec:
         annotations:
           description: "The MDC Operator has been down for more than 5 minutes."
           summary: "The MDC Operator is down. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
-      - alert: MobileDeveloperConsolePodCount
-        annotations:
-          description: "The Pod count for the MDC Server has changed in the last 5 minutes and is lower than the required minimum."
-          summary: "Pod count for Mobile Developer Console is {{ $value }}. Expected at least 2 pods. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="mobile-developer-console"})) or sum(kube_pod_status_ready{condition="true", namespace="mobile-developer-console"}) < 2
-        for: 5m
-        labels:
-          severity: warning


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9642

## What
- Remove MDCPodCount since it was considered redundant

## Why
According to the convention/standard, we have already the specific rule for each pod. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
