### PR TITLE
fix(Monitor) - Adding missing alerts (AEROGEAR-9644)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,8 @@ monitoring/install:
 	- kubectl create -n ${NAMESPACE} -f deploy/monitor/service_monitor.yaml
 	- kubectl create -n ${NAMESPACE} -f deploy/monitor/prometheus_rule.yaml
 	- kubectl create -n ${NAMESPACE} -f deploy/monitor/grafana_dashboard.yaml
+	- kubectl create -n ${NAMESPACE} -f deploy/monitor/mdc_service_monitor.yaml
+	- kubectl create -n ${NAMESPACE} -f deploy/monitor/mdc_prometheus_rule.yaml
 
 .PHONY: monitoring/uninstall
 monitoring/uninstall:
@@ -107,3 +109,6 @@ monitoring/uninstall:
 	- kubectl delete -n ${NAMESPACE} -f deploy/monitor/service_monitor.yaml
 	- kubectl delete -n ${NAMESPACE} -f deploy/monitor/prometheus_rule.yaml
 	- kubectl delete -n ${NAMESPACE} -f deploy/monitor/grafana_dashboard.yaml
+	- kubectl delete -n ${NAMESPACE} -f deploy/monitor/mdc_service_monitor.yaml
+	- kubectl delete -n ${NAMESPACE} -f deploy/monitor/mdc_prometheus_rule.yaml
+

--- a/deploy/monitor/mdc_prometheus_rule.yaml
+++ b/deploy/monitor/mdc_prometheus_rule.yaml
@@ -8,13 +8,41 @@ metadata:
   name: mdc-monitoring
 spec:
   groups:
-    - name: general.rules
-      rules:
-      - alert: MobileDeveloperConsoleDown
-        expr: absent(up{job="example-mdc-mdc"} == 1)
-        for: 5m
-        labels:
-          severity: critical
-        annotations:
-          description: "The Mobile Developer Console has been down for more than 5 minutes."
-          summary: "The Mobile Developer Console is down."
+  - name: general.rules
+    rules:
+    - alert: MobileDeveloperConsoleContainerDown
+      expr: absent(kube_pod_container_status_running{namespace="mobile-developer-console",container="mdc"}>=1)
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: "The MDC has been down for more than 5 minutes. "
+        summary: "The mobile-developer-console is down. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+    - alert: MobileDeveloperConsoleDown
+      expr: absent(kube_endpoint_address_available{endpoint="example-mdc-mdc"} >= 1)
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: "The MDC admin console has been down for more than 5 minutes. "
+        summary: "The mobile-developer-console admin console endpoint has been unavailable for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+    - alert: MobileDeveloperConsolePodCPUHigh
+      expr: "(rate(process_cpu_seconds_total{job='example-mdc-mdc'}[1m])) > (((kube_pod_container_resource_limits_cpu_cores{namespace='mobile-developer-console',container='mdc'})/100)*90)"
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: "The MDC pod has been at 90% CPU usage for more than 5 minutes"
+        summary: "The mobile-developer-console is reporting high cpu usage for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"
+    - alert: MobileDeveloperConsolePodMemoryHigh
+      expr: "(process_resident_memory_bytes{job='example-mdc-mdc'}) > (((kube_pod_container_resource_limits_memory_bytes{namespace='mobile-developer-console',container='mdc'})/100)*90)"
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: "The MDC pod has been at 90% memory usage for more than 5 minutes"
+        summary: "The mobile-developer-console is reporting high memory usage for more that 5 minutes. For more information see on the MDC at https://github.com/aerogear/mobile-developer-console"
+        sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-mdc.adoc"

--- a/deploy/monitor/prometheus_rule.yaml
+++ b/deploy/monitor/prometheus_rule.yaml
@@ -18,3 +18,4 @@ spec:
         annotations:
           description: "The MDC Operator has been down for more than 5 minutes."
           summary: "The MDC Operator is down. For more information on the MDC Operator, see https://github.com/aerogear/mobile-developer-console-operator"
+          sop_url: "https://github.com/aerogear/mobile-developer-console-operator/blob/0.1.2/SOP/SOP-operator.adoc"


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9644
https://issues.jboss.org/browse/AEROGEAR-9651

## What
### Regards the alerts which were missing
See its implementation: https://github.com/aerogear/mobile-developer-console-operator/blob/effd1558fcbaf100c93e72e365143ee6a134edda/deploy/monitor/mdc_prometheus_rule.yaml

It is missing: MDCServiceDown, MDCPodCPUHigh, MDCPodMemoryHigh + the specific ones which should be exported from the service. E.g https://github.com/aerogear/mobile-security-service-operator/blob/master/deploy/monitor/mss_prometheus_rule.yaml

### Regards the actions in the commands which were missing
- The Prometheus Rules and Monitor for the MDC service were implemented but were not added in the make commands. So the fix here was added these objects to be applied and deleted when the monitoring commands are called. 

## Steps to verify
- Check the rules here: https://prometheus-route-middleware-monitoring.apps.london-9dc0.openshiftworkshop.com/alerts
- Check that the MonitorService and Prometheus rules for the Service were added in the monitoring make commands.