### PR TITLE
Fix wrong custom resource type for keycloak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [0.1.1] - 2019-07-31
+### Changed
+- Use correct custom resource for Keycloak Realms
+
+## [0.1.0] - 2019-07-26
+### Added
+- Initial version of the operator

--- a/deploy/mobiledeveloper_role.yaml
+++ b/deploy/mobiledeveloper_role.yaml
@@ -64,7 +64,7 @@ rules:
   - apiGroups:
       - aerogear.org
     resources:
-      - keycloaks
+      - keycloakrealms
     verbs:
       - create
       - delete

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.0"
+	Version = "0.1.1"
 )


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9655

How I tested my change:

* SSH'd into the cluster mentioned in the JIRA
* Updated the role: `oc apply -f https://raw.githubusercontent.com/aerogear/mobile-developer-console-operator/ba7a40675bc6dab539d5474b446ce635b465e044/deploy/mobiledeveloper_role.yaml`
* In MDC, created a new binding for Keycloak. Saw the Keycloak info in MDC.
* I went to user facing RHSSO console and saw the realm there