### PR TITLE
increase MDC version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.1.3] - 2019-08-01
+
+## Changed
+
+- Updated version of Mobile Developer Console
+
 ## [0.1.2] - 2019-07-31
 
 ## Changed

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,7 @@ func New() Config {
 		OauthProxyImageStreamTag:  getEnv("OAUTH_PROXY_IMAGE_STREAM_TAG", "latest"),
 
 		// these are used when the image stream does not exist and created for the first time by the operator
-		MDCImageStreamInitialImage:        getEnv("MDC_IMAGE_STREAM_INITIAL_IMAGE", "quay.io/aerogear/mobile-developer-console:1.1.1"),
+		MDCImageStreamInitialImage:        getEnv("MDC_IMAGE_STREAM_INITIAL_IMAGE", "quay.io/aerogear/mobile-developer-console:1.1.2"),
 		OauthProxyImageStreamInitialImage: getEnv("OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE", "docker.io/openshift/oauth-proxy:v1.1.0"),
 
 		// override the default links displayed in MDC for each of the mobile services

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.2"
+	Version = "0.1.3"
 )


### PR DESCRIPTION
Changed release version of MDC to 1.1.2.

https://github.com/aerogear/mobile-developer-console/releases/tag/1.1.2