### PR TITLE
remove namespace and add cluster role binding

### DIFF
--- a/deploy/mobileclient_admin_cluster_role.yaml
+++ b/deploy/mobileclient_admin_cluster_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: mobileclient-admin-cluster
+  name: mobileclient-users
 rules:
   - apiGroups:
       - mobile.k8s.io
@@ -11,5 +11,3 @@ rules:
       - get
       - list
       - watch
-      - update
-      - patch

--- a/deploy/mobileclient_admin_cluster_role.yaml
+++ b/deploy/mobileclient_admin_cluster_role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mobileclient-admin-cluster
+rules:
+  - apiGroups:
+      - mobile.k8s.io
+    resources:
+      - mobileclients
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch

--- a/deploy/mobileclient_admin_cluster_rolebinding.yaml
+++ b/deploy/mobileclient_admin_cluster_rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: mobileclient-admin-cluster-binding
+  name: mobileclient-users-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mobileclient-admin-cluster
+  name: mobileclient-users
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group

--- a/deploy/mobileclient_admin_cluster_rolebinding.yaml
+++ b/deploy/mobileclient_admin_cluster_rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: mobile-developer-binding
+  name: mobileclient-admin-cluster-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: mobile-developer
+  kind: ClusterRole
+  name: mobileclient-admin-cluster
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group


### PR DESCRIPTION
The namespace field is not required on the RoleBinding file. It is causing an error when try to create the rolebinding in a different namespace.

Also we need to the clusterrole & clusterrolebinding to fix this issue: https://issues.jboss.org/browse/AEROGEAR-9690. 