### PR TITLE
AEROGEAR-9674 add view permission for project and routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.1.4] - 2019-08-02
+
+## Changed
+
+- Give project and route permission to mobile developer role to make OpenShift web console more usable
+
 ## [0.1.3] - 2019-08-01
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## [0.1.4] - 2019-08-02
+## [0.1.5] - 2019-08-02
 
 ## Changed
 
 - Give project and route permission to mobile developer role to make OpenShift web console more usable
+
+## [0.1.4] - 2019-08-02
+
+## Changed
+
+- Remove namespace in mobile developer role binding and add cluster role binding
 
 ## [0.1.3] - 2019-08-01
 

--- a/deploy/mobiledeveloper_role.yaml
+++ b/deploy/mobiledeveloper_role.yaml
@@ -73,3 +73,18 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - project.openshift.io
+    resources:
+      - projects
+    resourceNames:
+      - mobile-developer-console
+    verbs:
+      - get
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - list
+      - get

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.4"
+	Version = "0.1.5"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.3"
+	Version = "0.1.4"
 )


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-9674

As we discussed in Google chat, I didn't want to give "view" role to the entire namespace. In that case, users would be able to see pods, deployments etc. and even rsh into pods.

With this change, OpenShift console will work. Users will be able to click on the project `mobile-developer-console` and go to `Routes` and see the URL for MDC route. They will see error messages like "An error occurred connecting to the server. Failed to list services/v1 (status 403)" though. The error messages won't block anything but they're rather annoying.

@odra might have a better idea for extracting the MDC url.