### PR TITLE
AEROGEAR-9674 Namespace and project access no more for mobile devls

### DIFF
--- a/deploy/mobiledeveloper_role.yaml
+++ b/deploy/mobiledeveloper_role.yaml
@@ -6,14 +6,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - namespaces
-    verbs:
-      - get
-    resourceNames:
-      - mobile-developer-console
-  - apiGroups:
-      - ""
-    resources:
       - configmaps
     verbs:
       - create
@@ -73,14 +65,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - project.openshift.io
-    resources:
-      - projects
-    resourceNames:
-      - mobile-developer-console
-    verbs:
-      - get
   - apiGroups:
       - route.openshift.io
     resources:

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.5"
+	Version = "0.1.6"
 )


### PR DESCRIPTION
Verification:

* Login with admin
* `make cluster/clean && make cluster/prepare && make install-operator && make install-mdc`
* Login with developer
* `oc get route exampl-mdc-mdc-proxy -n mobile-developer-console`