### PR TITLE
feat(resources) : Add resource requests/limits to MDC & MDC operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,6 +19,13 @@ spec:
           command:
           - mobile-developer-console-operator
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 40m
+              memory: 64Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
+++ b/pkg/controller/mobiledeveloperconsole/mobiledeveloperconsole.go
@@ -2,6 +2,7 @@ package mobiledeveloperconsole
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/aerogear/mobile-developer-console-operator/pkg/util"
 	"github.com/pkg/errors"
@@ -237,6 +238,16 @@ func newMDCDeploymentConfig(cr *mdcv1alpha1.MobileDeveloperConsole) (*openshifta
 									ContainerPort: 4000,
 								},
 							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceLimitsMemory: resource.MustParse("128Gi"),
+									corev1.ResourceLimitsCPU:    resource.MustParse("60m"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+									corev1.ResourceCPU:    resource.MustParse("30m"),
+								},
+							},
 						},
 						{
 							Name:            cfg.OauthProxyContainerName,
@@ -261,6 +272,16 @@ func newMDCDeploymentConfig(cr *mdcv1alpha1.MobileDeveloperConsole) (*openshifta
 								"--pass-access-token=true",
 								"--scope=user:full",
 								"--bypass-auth-for=/about",
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceLimitsMemory: resource.MustParse("64Mi"),
+									corev1.ResourceLimitsCPU:    resource.MustParse("20m"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+								},
 							},
 						},
 					},


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9766

## What
- Change/Add Memory and CPU resources requested and limits for MDC, Oauth and Operator

## Steps to Verify
- Check the CI
- Update the operator.yaml with the image `cmacedo/mobile-developer-console-operator:AEROGEAR-9766`
- Run `make cluster/prepare install-operator`
- Run ` make install-mdc`

## Progress

- [x] Finished task
- [ ] TODO

## Local test:

### Operator Verification: 
<img width="573" alt="Screenshot 2019-08-22 at 11 30 42" src="https://user-images.githubusercontent.com/7708031/63507785-719f0780-c4d0-11e9-84f1-29a69dba8231.png">

### Service and Oauth: 

<img width="773" alt="Screenshot 2019-08-22 at 11 32 41" src="https://user-images.githubusercontent.com/7708031/63507846-94c9b700-c4d0-11e9-9ba9-99b5e1846a63.png">

