### PR TITLE
ci: specify folder with repo for getDevTag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,7 @@ pipeline {
             }
             environment {
                 // qe-pipeline-library step
-                DOCKER_DEV_TAG = getDevTag()
+                DOCKER_DEV_TAG = getDevTag("${env.CLONED_REPOSITORY_PATH}")
             }
             steps{
                 // qe-pipeline-library step


### PR DESCRIPTION
## Description

https://issues.jboss.org/browse/AGMS-1135

There is a bug in Jenkinsfile which prevents from publishing image for master branch [1]. This should fix it. Should not be merged before [2] is merged.

[1] https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/mobile-developer-console-operator/job/master/24/console
[2] https://github.com/aerogear/qe-pipeline-library/pull/6