### PR TITLE
ci: publish dev image pointing to master tag of operand

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,7 +167,7 @@ pipeline {
                 tagRemoteContainerImage(
                     credentialsId: "${env.CREDENTIALS_ID}",
                     sourceImage: "${env.OPERATOR_CONTAINER_IMAGE_NAME}",
-                    targetImage: "${env.OPERATOR_CONTAINER_IMAGE_NAME_latest}",
+                    targetImage: "${env.OPERATOR_CONTAINER_IMAGE_NAME_LATEST}",
                     deleteOriginalImage: false
                 )
             }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,12 +30,12 @@ func New() Config {
 		OauthProxyContainerName: getEnv("OAUTH_PROXY_CONTAINER_NAME", "mdc-oauth-proxy"),
 
 		MDCImageStreamName:        getEnv("MDC_IMAGE_STREAM_NAME", "mdc-imagestream"),
-		MDCImageStreamTag:         getEnv("MDC_IMAGE_STREAM_TAG", "master"),
+		MDCImageStreamTag:         getEnv("MDC_IMAGE_STREAM_TAG", "1.1.11"),
 		OauthProxyImageStreamName: getEnv("OAUTH_PROXY_IMAGE_STREAM_NAME", "mdc-oauth-proxy-imagestream"),
 		OauthProxyImageStreamTag:  getEnv("OAUTH_PROXY_IMAGE_STREAM_TAG", "latest"),
 
 		// these are used when the image stream does not exist and created for the first time by the operator
-		MDCImageStreamInitialImage:        getEnv("MDC_IMAGE_STREAM_INITIAL_IMAGE", "quay.io/aerogear/mobile-developer-console:master"),
+		MDCImageStreamInitialImage:        getEnv("MDC_IMAGE_STREAM_INITIAL_IMAGE", "quay.io/aerogear/mobile-developer-console:1.1.11"),
 		OauthProxyImageStreamInitialImage: getEnv("OAUTH_PROXY_IMAGE_STREAM_INITIAL_IMAGE", "quay.io/openshift/origin-oauth-proxy:4.2.0"),
 
 		// override the default links displayed in MDC for each of the mobile services


### PR DESCRIPTION
## Description

Previous PR changed version of operand to `master`. It might be safer to rebuild the image for nightly testing purposes. Only this image would point to master.